### PR TITLE
Add XDebug to PHP container (dormant)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-2015101
 RUN echo 'xdebug.remote_port=9001' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_host=172.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
 
 RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_port=9001' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,11 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_port=10000' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_port=9002' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
+#RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,14 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
 
 RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
+#RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_port=9001' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_autostart=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_host=10.30.3.46' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install pdo_pgsql \
     && docker-php-ext-install zip \
-    && docker-php-ext-install sockets \
-    && docker-php-ext-install xdebug \
-    && docker-php-ext-enable xdebug \
     ## APCu
     && pecl install apcu \
     && docker-php-ext-enable apcu \
@@ -22,7 +19,7 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     #&& docker-php-ext-enable imagick
     && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
 
-#RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
+RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
@@ -31,7 +28,7 @@ RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
-#RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,23 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
 
 RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
+
+RUN echo '[XDEBUG]' >> /usr/local/etc/php/php.ini
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
-#RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
-#RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.profiler_enable = 0
+RUN echo 'xdebug.profiler_enable_trigger = 0
+RUN echo 'xdebug.remote_enable = 0
+RUN echo 'xdebug.default_enable=0
+RUN echo 'xdebug.coverage_enable=0
+RUN echo 'xdebug.trace_enable_trigger=0
+RUN echo 'xdebug.auto_trace=0
+RUN echo 'xdebug.collect_includes=0
+
+RUN echo '[HOST=api-mono.waitr.local]' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_port=9002' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
-#RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
@@ -37,5 +46,3 @@ RUN mkdir -p /var/log/php-app
 RUN chown www-data:www-data /var/log/php-app
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     #&& docker-php-ext-enable imagick
     && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
 
+RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
+RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
+
 RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,25 +19,17 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     #&& docker-php-ext-enable imagick
     && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
 
+# Install and enable xdebug in "dormant" mode
 RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
-
-RUN echo '[XDEBUG]' >> /usr/local/etc/php/php.ini
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.profiler_enable = 0
-RUN echo 'xdebug.profiler_enable_trigger = 0
-RUN echo 'xdebug.remote_enable = 0
-RUN echo 'xdebug.default_enable=0
-RUN echo 'xdebug.coverage_enable=0
-RUN echo 'xdebug.trace_enable_trigger=0
-RUN echo 'xdebug.auto_trace=0
-RUN echo 'xdebug.collect_includes=0
-
-RUN echo '[HOST=api-mono.waitr.local]' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_port=9002' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.profiler_enable = 0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.profiler_enable_trigger = 0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_enable = 0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.coverage_enable=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.trace_enable_trigger=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.auto_trace=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.collect_includes=0' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install pdo_pgsql \
     && docker-php-ext-install zip \
+    && docker-php-ext-install sockets \
     ## APCu
     && pecl install apcu \
     && docker-php-ext-enable apcu \
@@ -26,7 +27,7 @@ RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_port=9001' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_autostart=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_host=172.254.254.254' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_host=10.30.3.46' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
 
-RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 
 RUN mkdir -p /var/log/php-app

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_port=9001' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_host=172.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     && docker-php-ext-install pdo_pgsql \
     && docker-php-ext-install zip \
     && docker-php-ext-install sockets \
+    && docker-php-ext-install xdebug \
+    && docker-php-ext-enable xdebug \
     ## APCu
     && pecl install apcu \
     && docker-php-ext-enable apcu \
@@ -20,16 +22,16 @@ RUN apt-get clean && apt-get update && apt-get install -y zlib1g-dev libicu-dev 
     #&& docker-php-ext-enable imagick
     && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
 
-RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
+#RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
 RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
+#RUN echo 'xdebug.idekey=IDEA_DEBUG' >> /usr/local/etc/php/php.ini
 #RUN echo 'xdebug.default_enable=0' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_port=9001' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_port=10000' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_connect_back=0' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_autostart=1' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.remote_handler=dbgb' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
+#RUN echo 'xdebug.remote_host=10.254.254.254' >> /usr/local/etc/php/php.ini
 
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-jessie-amd64.deb

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --no-cache -t waitr/eb-docker-php-7 .
+docker build --no-cache -t ajlozier/eb-docker-php-7 .

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --no-cache -t ajlozier/eb-docker-php-7 .
+docker build --no-cache -t waitr/eb-docker-php-7 .

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker push ajlozier/eb-docker-php-7
+docker push waitr/eb-docker-php-7

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker push waitr/eb-docker-php-7
+docker push ajlozier/eb-docker-php-7


### PR DESCRIPTION
This will add xdebug to the base image used to deploy `api-v2`. According to the settings defined here, xdebug will be installed but essentially dormant. I will be adding a separate `.user.ini` file to the local deployment process which will enable remote debugging (debug from the machine hosting the container).

If we would rather not add xdebug to this image, I'm open to other suggestions.